### PR TITLE
WIP: Allow non-standard cygwin path and fix a permission error

### DIFF
--- a/cygwin/Makefile.install
+++ b/cygwin/Makefile.install
@@ -201,12 +201,14 @@ installdest:
 	cp $(PROJECT_BASEDIR_DIR)/tests/wintartests/wintartest_seq001.bash $(DESTDIR)/usr/share/msnfs41client/tests/misc/wintartest_seq001.bash
 	@ printf "# Package ksh93&co (if available) since Cygwin does not ship with it yet\n"
 	if [[ -x '$(DESTDIR)/lib/msnfs41client/i686/nfsd.exe' ]] ; then \
-		[[ -x '/cygdrive/c/cygwin/bin/ksh93.exe' ]] && cp '/cygdrive/c/cygwin/bin/ksh93.exe' '$(DESTDIR)/lib/msnfs41client/i686/ksh93.i686.exe' ; \
-		[[ -x '/cygdrive/c/cygwin/bin/shcomp.exe' ]] && cp '/cygdrive/c/cygwin/bin/shcomp.exe' '$(DESTDIR)/lib/msnfs41client/i686/shcomp.i686.exe' ; \
+		cygroot_win="$$(cygpath -m /)" ; \
+		cygroot_i686="$$(cygpath -u "$${cygroot_win%64}")" ; \
+		[[ -x "$$cygroot_i686/bin/ksh93.exe" ]] && cp "$$cygroot_i686/bin/ksh93.exe" '$(DESTDIR)/lib/msnfs41client/i686/ksh93.i686.exe' ; \
+		[[ -x "$$cygroot_i686/bin/shcomp.exe" ]] && cp "$$cygroot_i686/bin/shcomp.exe" '$(DESTDIR)/lib/msnfs41client/i686/shcomp.i686.exe' ; \
 	fi
 	if [[ -x '$(DESTDIR)/lib/msnfs41client/x64/nfsd.exe' || -x '$(DESTDIR)/lib/msnfs41client/arm64/nfsd.exe' ]] ; then \
-		[[ -x '/cygdrive/c/cygwin64/bin/ksh93.exe' ]] && cp '/cygdrive/c/cygwin64/bin/ksh93.exe' '$(DESTDIR)/lib/msnfs41client/x64/ksh93.x86_64.exe' ; \
-		[[ -x '/cygdrive/c/cygwin64/bin/shcomp.exe' ]] && cp '/cygdrive/c/cygwin64/bin/shcomp.exe' '$(DESTDIR)/lib/msnfs41client/x64/shcomp.x86_64.exe' ; \
+		[[ -x '/bin/ksh93.exe' ]] && cp '/bin/ksh93.exe' '$(DESTDIR)/lib/msnfs41client/x64/ksh93.x86_64.exe' ; \
+		[[ -x '/bin/shcomp.exe' ]] && cp '/bin/shcomp.exe' '$(DESTDIR)/lib/msnfs41client/x64/shcomp.x86_64.exe' ; \
 	fi
 	cp $(PROJECT_BASEDIR_DIR)/cygwin/cygwin_ksh93/ksh.kshrc $(DESTDIR)/etc/ksh.kshrc
 	@ printf '# Packaging lib/contrib\n'

--- a/cygwin/devel/msnfs41client.bash
+++ b/cygwin/devel/msnfs41client.bash
@@ -105,14 +105,14 @@ function check_machine_arch
 
 	case "${uname_m}" in
 		'x86_64')
-			if [[ "${winpwd}" != 'C:\cygwin64\'* ]] ; then
+			if [[ "${winpwd}" != ?:\\cygwin64\\* ]] ; then
 				printf $"%s: Requires 64bit Cygwin\n" "$0" 1>&2
 				return 1
 			fi
 			return 0
 			;;
 		'i686')
-			if [[ "${winpwd}" != 'C:\cygwin\'* ]] ; then
+			if [[ "${winpwd}" != ?:\\cygwin\\* ]] ; then
 				printf $"%s: Requires 32bit Cygwin\n" "$0" 1>&2
 				return 1
 			fi
@@ -373,8 +373,8 @@ function nfsclient_install
 	# '/var/log/ms-nfs41-client-service.log' at any time
 	#
 	touch '/var/log/ms-nfs41-client-service.log'
-	chown SYSTEM:SYSTEM '/var/log/ms-nfs41-client-service.log'
 	chmod u+w,go-w '/var/log/ms-nfs41-client-service.log'
+	chown SYSTEM:SYSTEM '/var/log/ms-nfs41-client-service.log'
 
 	# install new 'ms-nfs41-client-service'
 	cygrunsrv --install \
@@ -405,8 +405,8 @@ function nfsclient_install
 	# '/var/log/ms-nfs41-client-globalmountall-service.log' at any time
 	#
 	touch '/var/log/ms-nfs41-client-globalmountall-service.log'
-	chown SYSTEM:SYSTEM '/var/log/ms-nfs41-client-globalmountall-service.log'
 	chmod u+w,go-w '/var/log/ms-nfs41-client-globalmountall-service.log'
+	chown SYSTEM:SYSTEM '/var/log/ms-nfs41-client-globalmountall-service.log'
 
 	# install new 'ms-nfs41-client-globalmountall-service'
 	cygrunsrv --install \

--- a/daemon/idmap_cygwin.c
+++ b/daemon/idmap_cygwin.c
@@ -49,6 +49,23 @@
     "/cygdrive/c/cygwin/lib/msnfs41client/cygwin_idmapper.ksh")
 #endif /* _WIN64 */
 
+static
+void get_cygwin_idmapper_script(
+    OUT char *restrict cmdbuff,
+    IN size_t cmdbuff_size)
+{
+    char cygwin_root[1024];
+
+    if (get_cygwin_root_for_nfsd(cygwin_root, sizeof(cygwin_root))) {
+        (void)snprintf(cmdbuff, cmdbuff_size,
+            "\"%s\\bin\\ksh93.exe\" /lib/msnfs41client/cygwin_idmapper.ksh",
+            cygwin_root);
+    }
+    else {
+        (void)StringCchCopyA(cmdbuff, cmdbuff_size, CYGWIN_IDMAPPER_SCRIPT);
+    }
+}
+
 #ifdef NFS41_DRIVER_FEATURE_IDMAPPER_CYGWIN
 static
 int cygwin_getent_passwd(
@@ -74,6 +91,7 @@ int cygwin_getent_passwd(
     cpv_name_val *cnv_cur = NULL;
     const char *localaccountname = NULL;
     const char *nfsowner = NULL;
+    char idmapper_script_cmd[1024];
 
     DPRINTF(CYGWINIDLVL,
         ("--> cygwin_getent_passwd(mode='%s',cfgname='%s',name='%s')\n",
@@ -100,9 +118,11 @@ int cygwin_getent_passwd(
     }
 
     /* fixme: better quoting for |name| needed */
+    get_cygwin_idmapper_script(idmapper_script_cmd,
+        sizeof(idmapper_script_cmd));
     (void)snprintf(cmdbuff, sizeof(cmdbuff),
         "%s \"%s\" \"%s\" \"%s\"",
-        CYGWIN_IDMAPPER_SCRIPT,
+        idmapper_script_cmd,
         mode,
         cfgname,
         name);
@@ -311,9 +331,9 @@ int cygwin_getent_group(
     int i = 0;
     cpv_name_val cnv[64] = { 0 };
     cpv_name_val *cnv_cur = NULL;
-
     const char *localgroupname = NULL;
     const char *nfsownergroup = NULL;
+    char idmapper_script_cmd[1024];
 
     DPRINTF(CYGWINIDLVL,
         ("--> cygwin_getent_group(mode='%s',cfgname='%s',name='%s')\n",
@@ -340,9 +360,11 @@ int cygwin_getent_group(
     }
 
     /* fixme: better quoting for |name| needed */
+    get_cygwin_idmapper_script(idmapper_script_cmd,
+        sizeof(idmapper_script_cmd));
     (void)snprintf(cmdbuff, sizeof(cmdbuff),
         "%s \"%s\" \"%s\" \"%s\"",
-        CYGWIN_IDMAPPER_SCRIPT,
+        idmapper_script_cmd,
         mode,
         cfgname,
         name);
@@ -545,6 +567,7 @@ int cygwin_map_nfsserverspec2idmappercfgname(
     cpv_name_val cnv[64] = { 0 };
     cpv_name_val *cnv_cur = NULL;
     const char *idmappercfgname = NULL;
+    char idmapper_script_cmd[1024];
 
     DPRINTF(CYGWINIDLVL,
         ("--> cygwin_map_nfsserverspec2idmappercfgname"
@@ -570,9 +593,11 @@ int cygwin_map_nfsserverspec2idmappercfgname(
         hostname, (unsigned int)port, (int)ispubnfs);
 
     /* fixme: better quoting for |serverspec_cpv| needed */
+    get_cygwin_idmapper_script(idmapper_script_cmd,
+        sizeof(idmapper_script_cmd));
     (void)snprintf(cmdbuff, sizeof(cmdbuff),
         "%s \"%s\" \"%s\"",
-        CYGWIN_IDMAPPER_SCRIPT,
+        idmapper_script_cmd,
         "map_nfsserverspec2idmappercfgname",
         serverspec_cpv);
     if ((script_pipe = subcmd_popen(cmdbuff)) == NULL) {
@@ -699,6 +724,7 @@ int cygwin_get_idmapconfig(
     int i = 0;
     cpv_name_val cnv[64] = { 0 };
     cpv_name_val *cnv_cur = NULL;
+    char idmapper_script_cmd[1024];
 
     DPRINTF(CYGWINIDLVL,
         ("--> cygwin_get_idmapconfig(idmappercfgname='%s')\n",
@@ -713,9 +739,11 @@ int cygwin_get_idmapconfig(
     }
 
     /* fixme: better quoting for |idmappercfgname| needed */
+    get_cygwin_idmapper_script(idmapper_script_cmd,
+        sizeof(idmapper_script_cmd));
     (void)snprintf(cmdbuff, sizeof(cmdbuff),
         "%s \"%s\" \"%s\"",
-        CYGWIN_IDMAPPER_SCRIPT,
+        idmapper_script_cmd,
         "print_idmapconfig",
         idmappercfgname);
     if ((script_pipe = subcmd_popen(cmdbuff)) == NULL) {

--- a/daemon/nfs41_daemon.c
+++ b/daemon/nfs41_daemon.c
@@ -578,13 +578,26 @@ void init_version_string(void)
     /*
      * Add cygwin version, if Cygwin idmapper is enabled
      */
+    char cygwin_uname_cmd[1024];
 #ifdef _WIN64
 #define CYGWIN_UNAME_A_CMD "C:\\cygwin64\\bin\\uname.exe -a"
 #else
 #define CYGWIN_UNAME_A_CMD "C:\\cygwin\\bin\\uname.exe -a"
 #endif /*  _WIN64 */
+    if (get_cygwin_root_for_nfsd(cygwin_uname_cmd,
+        sizeof(cygwin_uname_cmd))) {
+        char cygwin_root[1024];
+        (void)StringCchCopyA(cygwin_root, sizeof(cygwin_root),
+            cygwin_uname_cmd);
+        (void)snprintf(cygwin_uname_cmd, sizeof(cygwin_uname_cmd),
+            "\"%s\\bin\\uname.exe\" -a", cygwin_root);
+    }
+    else {
+        (void)StringCchCopyA(cygwin_uname_cmd, sizeof(cygwin_uname_cmd),
+            CYGWIN_UNAME_A_CMD);
+    }
     subcmd_popen_context *scmd_uname =
-        subcmd_popen(CYGWIN_UNAME_A_CMD);
+        subcmd_popen(cygwin_uname_cmd);
     if (scmd_uname) {
         char unamebuf[256];
         char *s;

--- a/daemon/util.c
+++ b/daemon/util.c
@@ -60,6 +60,42 @@ char *stpcpy(char *restrict s1, const char *restrict s2)
     return ((char *)memcpy(s1, s2, (l+1)*sizeof(char))) + l*sizeof(char);
 }
 
+bool get_cygwin_root_for_nfsd(
+    OUT char *restrict root_out,
+    IN size_t root_out_size)
+{
+    wchar_t moduleW[1024];
+    char moduleA[1024];
+    const char suffix[] = "\\lib\\msnfs41client\\nfsd.exe";
+    size_t module_len;
+    size_t suffix_len = strlen(suffix);
+    DWORD moduleW_len;
+
+    if ((root_out == NULL) || (root_out_size == 0))
+        return false;
+
+    moduleW_len = GetModuleFileNameW(NULL, moduleW,
+        (DWORD)(sizeof(moduleW) / sizeof(moduleW[0])));
+    if ((moduleW_len == 0) ||
+        (moduleW_len >= (sizeof(moduleW) / sizeof(moduleW[0])))) {
+        return false;
+    }
+
+    if (WideCharToMultiByte(CP_UTF8, 0, moduleW, -1, moduleA,
+        (int)sizeof(moduleA), NULL, NULL) == 0) {
+        return false;
+    }
+
+    module_len = strlen(moduleA);
+    if ((module_len <= suffix_len) ||
+        (_stricmp(moduleA + module_len - suffix_len, suffix) != 0)) {
+        return false;
+    }
+
+    moduleA[module_len - suffix_len] = '\0';
+    return SUCCEEDED(StringCchCopyA(root_out, root_out_size, moduleA));
+}
+
 const char* strip_path(
     IN const char *path,
     OUT uint32_t *len_out)

--- a/daemon/util.h
+++ b/daemon/util.h
@@ -79,6 +79,7 @@ typedef ULONGLONG util_reltimestamp;
 bool str_has_posixshell_specialchars(const char *restrict s);
 bool str_has_win32cmdexe_specialchars(const char *restrict s);
 char *stpcpy(char *restrict s1, const char *restrict s2);
+bool get_cygwin_root_for_nfsd(char *restrict root_out, size_t root_out_size);
 
 static __inline
 void *mempcpy(void *restrict dest, const void *restrict src, size_t n)


### PR DESCRIPTION
# First commit fbaebbe4ee376aee101224f03998ff1d8f087226

## Fix 1

Set `chmod` before `chown`.

On my system changing the permission after the file ownership didn't work:

```
+ chown SYSTEM:SYSTEM /var/log/ms-nfs41-client-globalmountall-service.log
+ chmod u+w,go-w /var/log/ms-nfs41-client-globalmountall-service.log
chmod: changing permissions of '/var/log/ms-nfs41-client-globalmountall-service.log': Permission denied
```

## Fix 2

Allow non-standard installation path for Cygwin

The first commit simply changed the check for `C:\Cygwin64\` in `/sbin/msnfs41client` to be drive-independent. However, this didn't solve all issues. The installation completed fine, but after installing the service couldn't be started due to another error:

```
WNetUseConnectionW('N:', '\\10.70.2.2@NFS@2049\') failed with error code 1450.
Insufficient system resources exist to complete the requested service.
```

As a temporary workaround I tried to create  a junction:

```
mklink /J C:\cygwin64 F:\cygwin64
```

The fixes in the first commit plus this link allowed the service to start successfully with Cygwin installed on a different drive than `C:` (`F:` in this example).

# Second commit 20a26ba0b5c5fc3f09e2c7aa7a03c002c9d67984

The second commit was prepared by AI but wasn't tested. It was meant to fix all places where the current code relies on a hardcoded path to `C:\Cygwin64\'.

I don't have the dev environment set up to test. It would be great if someone could test, otherwise I will set it up and test separately. Until then I will mark this PR as WIP.

The AI description of these changes below:

### What changed

- Derive the Cygwin root dynamically from the installed `nfsd.exe` location instead of hardcoding `C:\cygwin64` / `C:\cygwin`.
- Use that derived root when launching:
  - `ksh93.exe` for the Cygwin idmapper
  - `uname.exe` for the daemon version probe
- Keep the old hardcoded paths only as a fallback if the runtime path cannot be derived.
- Make `cygwin/Makefile.install` package `ksh93.exe` and `shcomp.exe` from the current Cygwin installation instead of fixed `/cygdrive/c/...` paths.

### Why

The service log showed that the mount path still tried to execute:

- `C:\cygwin64\bin\ksh93.exe`
- `/cygdrive/c/cygwin64/lib/msnfs41client/cygwin_idmapper.ksh`

After moving Cygwin to another drive, those paths no longer exist, which breaks idmapper startup during mount. These changes make the daemon and packaging drive-independent.

### Files changed

- `daemon/util.h`
- `daemon/util.c`
- `daemon/idmap_cygwin.c`
- `daemon/nfs41_daemon.c`
- `cygwin/Makefile.install`